### PR TITLE
Summary on node

### DIFF
--- a/foresight.iml
+++ b/foresight.iml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.jira:jira-api:6.1.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.annotations:atlassian-annotations:0.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.ofbiz:entityengine-share:1.0.40" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xerces:xercesImpl:2.4.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.ofbiz:entityengine:1.0.40" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jta:jta:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-collections:commons-collections:3.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.util.concurrent:atlassian-util-concurrent:0.0.9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.weakref:jmxutils:1.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.ju-n.commons-dbcp-jmx:commons-dbcp-jmx-jdbc4:0.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-dbcp:commons-dbcp:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-pool:commons-pool:1.5.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: opensymphony:webwork:1.4-atlassian-30" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.html:atlassian-html-encoder:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: webwork:pell-multipart-request:1.31.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.lucene:lucene-core:3.3.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.core:atlassian-core:4.6.10" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.sanselan:sanselan:0.97-incubator" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: dom4j:dom4j:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: xml-apis:xml-apis:1.0.b2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jaxen:jaxen:1.0-FCS" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: saxpath:saxpath:1.0-FCS" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: msv:msv:20020414" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: relaxngDatatype:relaxngDatatype:20020414" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: isorelax:isorelax:20020414" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.image:atlassian-image-consumer:1.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.media:jai-core:1.1.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sun:jai_codec:1.1.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.extras:atlassian-extras:2.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-codec:commons-codec:1.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.velocity:atlassian-velocity:1.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: opensymphony:oscore:2.2.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.velocity:velocity:1.6.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: osworkflow:osworkflow:2.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: opensymphony:propertyset:1.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.crowd:embedded-crowd-api:2.7.0-beta2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-lang3:3.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:jsr305:2.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:guava:10.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.fugue:fugue:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.jackson:jackson-core-asl:1.9.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.jackson:jackson-mapper-asl:1.9.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.mail:atlassian-mail:2.5.0-m7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-beanutils:commons-beanutils:1.6.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-digester:commons-digester:1.4.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.mail:mail:1.4.5" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: oro:oro:2.0.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: atlassian-bandana:atlassian-bandana:0.1.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.threadlocal:atlassian-threadlocal:1.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.applinks:applinks-api:4.0.9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.velocity.htmlsafe:velocity-htmlsafe:1.2.1-m2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.plugins:atlassian-plugins-webfragment:3.0.0-m9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.plugins:atlassian-plugins-core:3.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.event:atlassian-event:2.2.0-m1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jfree:jfreechart:1.0.13" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.plugins:atlassian-plugins-webresource:3.0.0-m24" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.plugins:atlassian-plugins-webresource-common:3.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.plugins:atlassian-plugins-webresource-api:3.0.0-m24" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.json:atlassian-json-api:0.9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.tuckey:urlrewritefilter:4.0.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: jfree:jcommon:1.0.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.sal:sal-api:2.10.9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.gadgets:atlassian-gadgets-api:3.2.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.johnson:atlassian-johnson:1.1.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: joda-time:joda-time:2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-lang:commons-lang:2.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-io:commons-io:1.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-httpclient:commons-httpclient:3.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: log4j:log4j:1.2.16" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-api:1.6.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: quartz:quartz:1.5.1-atlassian-2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.profiling:atlassian-profiling:1.9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.atlassian.analytics:analytics-api:2.28" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:servlet-api:2.4" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.atlassian.plugins:atlassian-plugins-osgi-testrunner:1.1.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.wink:wink-client:1.1.3-incubating" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.wink:wink-common:1.1.3-incubating" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.geronimo.specs:geronimo-annotation_1.1_spec:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: javax.xml.bind:jaxb-api:2.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: javax.xml.stream:stax-api:1.0-2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.sun.xml.bind:jaxb-impl:2.2.1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.activation:activation:1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.ws.rs:jsr311-api:1.1.1" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.2.2-atlassian-1" level="project" />
+  </component>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ca.appbox.jira</groupId>
     <artifactId>foresight</artifactId>
-    <version>0.8.1-jira6</version>
+    <version>0.8.2-jira6</version>
 
     <organization>
         <name>Solutions Appbox inc.</name>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 
     <properties>
         <jira.version>6.1.5</jira.version>
-        <amps.version>4.2.10</amps.version>
+        <amps.version>5.0.2</amps.version>
         <plugin.testrunner.version>1.1.2</plugin.testrunner.version>
 		<testkit.version>5.2.26</testkit.version>
     </properties>

--- a/src/main/resources/js/foresight.js
+++ b/src/main/resources/js/foresight.js
@@ -156,7 +156,7 @@ function show_graph() {
 		text.append("svg:text")
 		    .attr("x", 8)
 		    .attr("y", ".31em")
-		    .text(function(d) { return d.name; })
+		    .text(function(d) { return d.summary + " (" + d.name + ")"; })
 		    .attr("class", function(d) { if (d.status == 'Resolved' || d.status == 'Closed') { return "foresight-text-striked" } })
 			.append("svg:title")
 			.text(function(d) { return d.summary; });


### PR DESCRIPTION
GES-2784

Show the issue summary in addition to the name on the graph nodes.  Previously the summary was hidden in a svg:title tag.
# Verification Steps
- [ ] Go to MSP-11149 on the Jira staging server
- [ ] Click the Dependencies Tab
- [ ] Click Outward edges
- [ ] VERIFY you can see the issue summaries
  ![screen shot 2015-04-09 at 3 30 49 pm](https://cloud.githubusercontent.com/assets/2230482/7076215/6c1f86ba-decd-11e4-9abc-c2e0a72b2a07.png)
# Merge
- [ ] Merge to rapid7 branch
# Install on production
## Atlassian Setup
- [ ] `brew tap atlassian/tap`
- [ ] `brew install atlassian/tap/atlassian-plugin-sdk`
## Maven packaging
- [ ] `atlas-mvn package`
## Installation
- [ ] Go to Jira production server
- [ ] Click the Jira Admin menu Gear
- [ ] Click Add-ons
- [ ] Click Manage Add-ons
- [ ] Click upload add-on
- [ ] Select the  `limhoff-r7/foresight/target/foresight-0.8.2-jira6.jar` produced by `atlas-mvn package`
